### PR TITLE
Finish

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -128,5 +128,6 @@ public class Main {
 
 
 
+
     }
 }


### PR DESCRIPTION
Привет! По ходу решения задач, оставлял вопросы в комментариях,
Самый главный вопрос, конечно же, почему я не могу присвоить переменной тип byte или short, если ее инициализирует какое-то выражение, а не просто число.
А по 8 Задаче, с Денисом очень странные дела... Если повышать его зп не на 10%, а на 20, например, или уменьшать на 10%, считает норм. Но как только коэф-т 10%, в конечном значении получаем 92059.00000000001 рублей...

Еще у меня была догадка, что мы не можем задать переменной тип рангом ниже, чем тем, которым она инициализируется.
Например:
    short a = 30000;
    short b = 10000;
    var c = a/b:
Тут "с" мы ожидаем "3", что входит в диапазон byte, но "под с" происходит арифметическая операция со старшими переменными short, поэтому как минимум мы должны задать short... Но НЕТ. Код работает только с Int, long. var, float
